### PR TITLE
fix shebang line

### DIFF
--- a/zaread
+++ b/zaread
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env bash
 ## zaread - a simple script created by paoloap.
 
 # zaread cache path


### PR DESCRIPTION
this script uses `bash`isms such as `[[ ]]`, so the shebang line should specify `bash`