### PR TITLE
Allow typst to recompile on changes

### DIFF
--- a/zaread
+++ b/zaread
@@ -13,6 +13,7 @@ MOBI_CMD="ebook-convert"
 OFFICE_CMD="soffice"
 MD_CMD="md2pdf"
 TYPST_CMD="typst"
+TYPST_ARG="compile" # Can be changed to "watch"
 MD_ARG=""
 MOBI_ARG=""
 OFFICE_ARG=""
@@ -198,7 +199,8 @@ case "$file_converter" in
 			eval "$MD_CMD" "$MD_ARG" \""$directory/$file"\" -o \""$ZA_CACHE_DIR/$pdffile"\"
 			;;
 		"$TYPST_CMD")
-			eval "$TYPST_CMD" compile \""$directory/$file"\" \""$ZA_CACHE_DIR/$pdffile"\"
+			eval "$TYPST_CMD" "$TYPST_ARG" \""$directory/$file"\" \""$ZA_CACHE_DIR/$pdffile"\" --open $READER
+			exit
 			;;
 		esac
 	else


### PR DESCRIPTION
The goal of this PR is to allow typst to automatically recompile on changes. This is optional and should be enabled from `zareadrc`: 
```
TYPST_CMD="typst watch"
```

When using `typst watch`, the process does not end. This is why I launch `$READER` directly from typst.

1. We could consider having something like `zaread --clean`, cleaning cache and old processes. 
2. The ideal solution would be to get `typst` to end once `$READER` is closed, but I don't know how to do it.


