### PR TITLE
Allow zaread to open files detected as text/x-objective-c

### DIFF
--- a/zaread
+++ b/zaread
@@ -129,7 +129,8 @@ else
 		esac
 		;;
 	"text/plain" | \
-		"text/x-c")
+		"text/x-c" | \
+		"text/x-objective-c" )
 		case "$file" in
 		*.md)
 			# If the file is a markdown we convert it using $MD_CMD.


### PR DESCRIPTION
Some text files are automatically detected as `text/x-objective-c`.

This PR makes zaread work for those files.