### PR TITLE
Add text/x-script.python mime-type

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ If you are opening a pdf or an epub it doesn't do anything more than launch zath
 
 ### What file formats does zaread support?
 - PDF
+- DJVU
 - EPUB
 - OOXML documents (docx, xlsx, pptx)
 - Old MS Office documents (doc, xls, ppt)

--- a/zaread
+++ b/zaread
@@ -130,7 +130,8 @@ else
 		;;
 	"text/plain" | \
 		"text/x-c" | \
-		"text/x-objective-c" )
+		"text/x-objective-c" | \
+		"text/x-script.python" )
 		case "$file" in
 		*.md)
 			# If the file is a markdown we convert it using $MD_CMD.


### PR DESCRIPTION
Some typst documents get recognized as `text/x-script.python`.
This PR adds support for them.

Also I forgot to add djvu to the readme.